### PR TITLE
Unknown blocks for BE to JE should be air

### DIFF
--- a/src/bedrock-block-data.cpp
+++ b/src/bedrock-block-data.cpp
@@ -62,7 +62,11 @@ public:
   }
 
   static std::shared_ptr<mcfile::je::Block const> Identity(mcfile::be::Block const &b, int dataVersion) {
-    return mcfile::je::Block::FromName(b.fName, dataVersion);
+    if (auto block = mcfile::je::Block::FromName(b.fName, dataVersion); block) {
+      return block;
+    }
+    // Unknown block should be air
+    return mcfile::je::Block::FromId(mcfile::blocks::minecraft::air, dataVersion);
   }
 
 private:


### PR DESCRIPTION
Some cheaters leave many, many Education Edition blocks (e.g. `underwater_torch` ) around the world of my server years ago, and finding and pruning all of them is impossible for a years-old save that has 1.2GB.

Literally copying block ID may cause an assertion error for non-JE and non-BE blocks, so they should be air when converted.
Simple patch, not tested, hope it will work.